### PR TITLE
Makes the index, startTime, count public properties

### DIFF
--- a/Sources/Progress.swift
+++ b/Sources/Progress.swift
@@ -54,10 +54,10 @@ struct ProgressBarTerminalPrinter: ProgressBarPrinter {
 // MARK: - ProgressBar
 
 public struct ProgressBar {
-    var index = 0
-    let startTime = getTimeOfDay()
+    private(set) public var index = 0
+    public let startTime = getTimeOfDay()
     
-    let count: Int
+    public let count: Int
     let configuration: [ProgressElementType]?
 
     public static var defaultConfiguration: [ProgressElementType] = [ProgressIndex(), ProgressBarLine(), ProgressTimeEstimates()]


### PR DESCRIPTION
Makes the index, startTime, count public properties to allow better reuse outside the framework. In my case I wanted to add a custom printer in my application, and needed access to the `index` of the progress bar.