### PR TITLE
Update Package.swift to 4.0 syntax

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,13 @@
+// swift-tools-version:4.0
+
 import PackageDescription
 
 let package = Package(
-    name: "Progress"
+    name: "Progress",
+    products: [
+        .library(name: "Progress", targets: ["Progress"]),
+    ],
+    targets: [
+        .target(name: "Progress", dependencies: [], path: "Sources"),
+    ]
 )


### PR DESCRIPTION
The swift package fails to build with Swift 5/Xcode 10.2 with a message that tools version 4.0 is now the minimum allowed.