### PR TITLE
fix off-by-one counting error

### DIFF
--- a/Sources/Progress.swift
+++ b/Sources/Progress.swift
@@ -43,7 +43,7 @@ struct ProgressBarTerminalPrinter: ProgressBarPrinter {
     
     mutating func display(_ progressBar: ProgressBar) {
         let currentTime = getTimeOfDay()
-        if (currentTime - lastPrintedTime > 0.1 || progressBar.index == progressBar.count) {
+        if (currentTime - lastPrintedTime > 0.1 || progressBar.element == progressBar.count) {
             print("\u{1B}[1A\u{1B}[K\(progressBar.value)")
             lastPrintedTime = currentTime
         }
@@ -54,7 +54,7 @@ struct ProgressBarTerminalPrinter: ProgressBarPrinter {
 // MARK: - ProgressBar
 
 public struct ProgressBar {
-    private(set) public var index = 0
+    private(set) public var element = 1
     public let startTime = getTimeOfDay()
     
     public let count: Int
@@ -77,15 +77,15 @@ public struct ProgressBar {
     }
     
     public mutating func next() {
-        guard index <= count else { return }
+        guard element <= count else { return }
         let anotherSelf = self
         printer.display(anotherSelf)
-        index += 1
+        element += 1
     }
 
     public mutating func setValue(_ index: Int) {
         guard index <= count && index >= 0 else { return }
-        self.index = index
+        self.element = index
         let anotherSelf = self
         printer.display(anotherSelf)
     }

--- a/Sources/ProgressElements.swift
+++ b/Sources/ProgressElements.swift
@@ -45,7 +45,7 @@ public struct ProgressBarLine: ProgressElementType {
         if progressBar.count == 0 {
             completedBarElements = barLength
         } else {
-            completedBarElements = Int(Double(barLength) * (Double(progressBar.index) / Double(progressBar.count)))
+            completedBarElements = Int(Double(barLength) * (Double(progressBar.element) / Double(progressBar.count)))
         }
         
         var barArray = [String](repeating: "-", count: completedBarElements)
@@ -60,7 +60,7 @@ public struct ProgressIndex: ProgressElementType {
     public init() {}
     
     public func value(_ progressBar: ProgressBar) -> String {
-        return "\(progressBar.index) of \(progressBar.count)"
+        return "\(progressBar.element) of \(progressBar.count)"
     }
 }
 
@@ -76,7 +76,7 @@ public struct ProgressPercent: ProgressElementType {
     public func value(_ progressBar: ProgressBar) -> String {
         var percentDone = 100.0
         if progressBar.count > 0 {
-            percentDone = Double(progressBar.index) / Double(progressBar.count) * 100
+            percentDone = Double(progressBar.element) / Double(progressBar.count) * 100
         }
         return "\(percentDone.format(decimalPlaces))%"
     }
@@ -92,9 +92,9 @@ public struct ProgressTimeEstimates: ProgressElementType {
         
         var itemsPerSecond = 0.0
         var estimatedTimeRemaining = 0.0
-        if progressBar.index > 0 {
-            itemsPerSecond = Double(progressBar.index) / totalTime
-            estimatedTimeRemaining = Double(progressBar.count - progressBar.index) / itemsPerSecond
+        if progressBar.element > 0 {
+            itemsPerSecond = Double(progressBar.element) / totalTime
+            estimatedTimeRemaining = Double(progressBar.count - progressBar.element) / itemsPerSecond
         }
         
         let estimatedTimeRemainingString = formatDuration(estimatedTimeRemaining)


### PR DESCRIPTION
The progress meter never actually made it to 100%.

Tested as follows:

    var progress = ProgressBar(count: 5)
    for i in 0..<5 {
        print("printing \(i)")
        progress.next()
    }

which produced the following output:

    printing 0
    0 of 5 Consolidating entries: [                              ] 0% ETA: 00:00:00 (at 0.00) it/s)
    printing 1
    printing 2
    printing 3
    printing 4
    4 of 5 Consolidating entries: [------------------------      ] 80% ETA: 00:00:00 (at 85163.53) it/s)

This is because the code was comparing 0-based indices with counts of
    objects processed and left to process. The 0-based index would
    always be 1 less than the count, so progress would never get to 100%.